### PR TITLE
feat: support filesystem disks

### DIFF
--- a/config/postman.php
+++ b/config/postman.php
@@ -144,10 +144,12 @@ return [
     |
     */
     'output' => [
+        'driver' => env('POSTMAN_STORAGE_DISK', 'local'),
+
         // Storage path for generated files
-        'path' => storage_path('postman'),
+        'path' => env('POSTMAN_STORAGE_DIR', storage_path('postman')),
 
         // File naming pattern (date will be appended)
-        'filename' => 'api_collection',
+        'filename' => env('POSTMAN_STORAGE_FILE', 'api_collection'),
     ],
 ];

--- a/src/Services/PostmanFormatter.php
+++ b/src/Services/PostmanFormatter.php
@@ -2,6 +2,7 @@
 
 namespace YasinTgh\LaravelPostman\Services;
 
+use Illuminate\Support\Facades\Storage;
 use YasinTgh\LaravelPostman\Collections\Builder;
 
 class PostmanFormatter
@@ -20,21 +21,19 @@ class PostmanFormatter
 
     public function save(array $collection): string
     {
-        $output_config = $this->config['output'] ?? [];
+        $driver = data_get($this->config, 'output.driver');
+        $path = data_get($this->config, 'output.path');
+        $filename = data_get($this->config, 'output.filename');
 
-        $path = $output_config['path'] ?? storage_path('postman');
+        $disk = Storage::build([
+            'driver' => $driver,
+            'root' => $path,
+        ]);
 
-        if (!file_exists($path)) {
-            mkdir($path, 0755, true);
-        }
+        $contents = json_encode($collection, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        $filePath = $path . '/' . $output_config['filename'];
+        $disk->put($filename, $contents);
 
-        file_put_contents(
-            $filePath,
-            json_encode($collection, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
-        );
-
-        return $filePath;
+        return $disk->path($filename);
     }
 }


### PR DESCRIPTION
I accidentally uploaded my Postman collection to S3 while testing this out 😄

Summary of changes:
1. Support filesystem disks other than `local`
2. Leverage `Storage` facade for file creation
3. Allow output customization in `.env` to work better in team setting