### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "symfony/console": "^6.0|^7.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "symfony/console": "^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Add `illuminate/support ^13.0` to support Laravel 13 installations
- Add `symfony/console ^8.0` since Laravel 13 supports Symfony 8

Laravel 13 requires PHP 8.3+, uses `illuminate/support ^13.0`, and depends on `symfony/console ^7.4.0 || ^8.0.0`. This PR extends the existing version constraints to include these versions.